### PR TITLE
Enforce abstract base class nature of Command.

### DIFF
--- a/Test/test_commands.py
+++ b/Test/test_commands.py
@@ -247,7 +247,11 @@ class CommandTest(unittest.TestCase):
                                         ))
         print cmds
         self.assertEqual(str(cmds), "[\n    Parallel(\n        Sequence(\n            Comment('Chain1'),\n            Set('run', 1),\n            Delay(2),\n            Set('run', 0)\n        ),\n        Sequence(\n            Comment('Chain2'),\n            Set('foo', 1),\n            Delay(2),\n            Set('foo', 0)\n        )\n    )\n]")
-    
+
+    def testCommandAbstractMethodsMustBeImplemented(self):
+        class IncompleteCommand(Command):
+            pass
+        self.assertRaises(TypeError, IncompleteCommand)
 
 if __name__ == "__main__":
     unittest.main()

--- a/scan/commands/command.py
+++ b/scan/commands/command.py
@@ -2,9 +2,10 @@
 Created on Mar 8,2015
 @author: qiuyx
 '''
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 
 class Command(object):
+    __metaclass__ = ABCMeta
     """Base class for all commands."""
     
     @abstractmethod


### PR DESCRIPTION
The @abstractmethod annotation was not previously effective.