### PR TITLE
Turn CommandSequence into Python list, add += operator

### DIFF
--- a/scan/commands/commandsequence.py
+++ b/scan/commands/commandsequence.py
@@ -11,7 +11,7 @@ except:
 from scan.commands.command import Command
 from scan.util.xml_helper import indent
 
-class CommandSequence(object):
+class CommandSequence(list):
     """A sequence of scan commands
     
     Basically a list of commands,
@@ -21,19 +21,16 @@ class CommandSequence(object):
     :param commands: One or more commands, or existing list of commands.
     """
     def __init__(self, *commands):
-        self.commands=[]
-        for command in commands:
-            # Append individual command
-            if isinstance(command, Command):
-                self.commands.append(command)
-            else:
-                # Assume iterable tuple, list, set, .. and append its content
-                self.commands += list(command)
+        super(CommandSequence, self).__init__()
+        self.append(*commands)
             
-    def __len__(self):
-        """:return: Number of commands"""
-        return len(self.commands)
-    
+    def __iadd__(self, other):
+        if isinstance(other, list):
+            self.append(*other)
+        else:
+            self.append(other)
+        return self
+
     def append(self, *commands):
         """Append more commands to the sequence
         
@@ -42,15 +39,15 @@ class CommandSequence(object):
         for command in commands:
             # Append individual command
             if isinstance(command, Command):
-                self.commands.append(command)
+                super(CommandSequence, self).append(command)
             else:
                 # Assume iterable tuple, list, set, .. and append its content
-                self.commands += list(command)
+                self.append(list(command))
     
     def genSCN(self):
         """:return: Command in XML format suitable for scan server"""
         scn = ET.Element('commands')
-        for c in self.commands:
+        for c in self:
             scn.append(c.genXML())
         
         indent(scn)
@@ -71,11 +68,11 @@ class CommandSequence(object):
             ]
             
         """
-        if len(self.commands) == 0:
+        if len(self) == 0:
             return "[]"
 
         result = "["
-        for cmd in self.commands:
+        for cmd in self:
             result += "\n" + cmd.format(1)
         result += "\n]"
         return result
@@ -84,7 +81,7 @@ class CommandSequence(object):
         return self.format()
     
     def __repr__(self):
-        return "CommandSequence(" + str(self.commands) + ")"
+        return "CommandSequence(" + str(self) + ")"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With CommandSequence acting as Python list, it inherits all functions
to manage the list. In addition, overloaded += operator makes it easy
to add one or more commands.